### PR TITLE
Remove eol versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,56 +4,38 @@ cache: pip
 matrix:
   fast_finish: true
   include:
-  - python: 2.7
-    env: TOX_ENV=py27-dj19
-  - python: 3.4
-    env: TOX_ENV=py34-dj19
-  - python: 3.5
-    env: TOX_ENV=py35-dj19
-  - python: 2.7
-    env: TOX_ENV=py27-dj110
-  - python: 3.4
-    env: TOX_ENV=py34-dj110
-  - python: 3.5
-    env: TOX_ENV=py35-dj110
-  - python: 2.7
-    env: TOX_ENV=py27-dj111
-  - python: pypy
-    env: TOX_ENV=pypy-dj111
-  - python: 3.4
-    env: TOX_ENV=py34-dj111
-  - python: 3.5
-    env: TOX_ENV=py35-dj111
-  - python: 3.6
-    env: TOX_ENV=py36-dj111
-  - python: pypy3
-    env: TOX_ENV=pypy3-dj111
-  - python: 3.4
-    env: TOX_ENV=py34-dj20
-  - python: 3.5
-    env: TOX_ENV=py35-dj20
-  - python: 3.6
-    env: TOX_ENV=py36-dj20
-  - python: pypy3
-    env: TOX_ENV=pypy3-dj20
-  - python: 3.5
-    env: TOX_ENV=py35-djdev
-  - python: 3.6
-    env: TOX_ENV=py36-djdev
-  - python: 3.6
-    env: TOX_ENV=flake8
-  - python: 3.6
-    env: TOX_ENV=isort
-  - python: 3.6
-    env: TOX_ENV=readme
-  - python: 3.6
-    env: TOX_ENV=check-manifest
+  - env: TOX_ENV=py27-dj111
+    python: 2.7
+  - env: TOX_ENV=py34-dj111
+    python: 3.4
+  - env: TOX_ENV=pypy-dj111
+    python: pypy
+  - env: TOX_ENV=py35-dj111
+    python: 3.5
+  - env: TOX_ENV=py36-dj111
+    python: 3.6
+  - env: TOX_ENV=pypy3-dj111
+    python: pypy3
+  - env: TOX_ENV=py34-dj20
+    python: 3.4
+  - env: TOX_ENV=py35-dj20
+    python: 3.5
+  - env: TOX_ENV=py36-dj20
+    python: 3.6
+  - env: TOX_ENV=pypy3-dj20
+    python: pypy3
+  - env: TOX_ENV=py35-djmaster
+    python: 3.5
+  - env: TOX_ENV=py36-djmaster
+    python: 3.6
+  - env: TOX_ENV=flake8
+  - env: TOX_ENV=isort
+  - env: TOX_ENV=readme
+  - env: TOX_ENV=check-manifest
   allow_failures:
-  - env: TOX_ENV=py35-djdev
-  - env: TOX_ENV=py36-djdev
+  - env: TOX_ENV=py35-djmaster
+  - env: TOX_ENV=py36-djmaster
   # Use old sqlite3 that does not support shared memory
-  - env: TOX_ENV=py27-dj19
-  - env: TOX_ENV=py27-dj110
   - env: TOX_ENV=py27-dj111
   - env: TOX_ENV=pypy-dj111
 addons:

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,16 @@
 History
 =======
 
+1.1.0 (2018-03-30)_
+
+* Drop support for Django 1.9, 1.10
+
+1.0.0 (2018-02-02)
+------------------
+
+* Add support for Django 2.0
+* Drop support for Django 1.8
+
 0.0.1 (2017-05-22)
 ------------------
 

--- a/horizon/__init__.py
+++ b/horizon/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """UNCOVER TRUTH Inc."""
 __email__ = 'develop@uncovertruth.co.jp'
-__version__ = '1.0.0'
+__version__ = '1.1.0'

--- a/horizon/models.py
+++ b/horizon/models.py
@@ -20,7 +20,6 @@ from .utils import (
     get_or_create_index,
 )
 
-
 _HORIZON_OPTIONS = (
     'horizontal_group',
     'horizontal_key',

--- a/horizon/routers.py
+++ b/horizon/routers.py
@@ -15,7 +15,6 @@ from .utils import (
     get_or_create_index,
 )
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/horizon/settings.py
+++ b/horizon/settings.py
@@ -5,7 +5,6 @@ from __future__ import absolute_import, unicode_literals
 from django.conf import settings
 from django.utils.lru_cache import lru_cache
 
-
 CONFIG_DEFAULTS = {
     'GROUPS': {},
     'METADATA_MODEL': None,

--- a/horizon/utils.py
+++ b/horizon/utils.py
@@ -5,7 +5,6 @@ from __future__ import absolute_import, unicode_literals
 import logging
 import random
 
-import django
 from django.apps import apps
 from django.core.exceptions import ImproperlyConfigured
 
@@ -17,11 +16,7 @@ logger = logging.getLogger(__name__)
 
 def get_metadata_model():
     try:
-        if (1, 11) > django.VERSION:
-            return apps.get_model(get_config()['METADATA_MODEL'])
-        else:
-            return apps.get_model(get_config()['METADATA_MODEL'], require_ready=False)
-
+        return apps.get_model(get_config()['METADATA_MODEL'], require_ready=False)
     except ValueError:
         raise ImproperlyConfigured("METADATA_MODEL must be of the form 'app_label.model_name'")
     except LookupError:

--- a/horizon/utils.py
+++ b/horizon/utils.py
@@ -10,7 +10,6 @@ from django.core.exceptions import ImproperlyConfigured
 
 from .settings import get_config
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,6 +25,7 @@ exclude =
 include_trailing_comma=True
 line_length=80
 multi_line_output=3
+skip=migrations
 not_skip=__init__.py
 known_first_party=horizon
 

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open('HISTORY.rst') as history_file:
     history = history_file.read()
 
 requirements = [
-    'Django>=1.9',
+    'Django>=1.11',
 ]
 
 test_requirements = [
@@ -38,8 +38,6 @@ setup(
     classifiers=[
         'Development Status :: 2 - Pre-Alpha',
         'Environment :: Web Environment',
-        'Framework :: Django :: 1.9',
-        'Framework :: Django :: 1.10',
         'Framework :: Django :: 1.11',
         'Framework :: Django :: 2.0',
         'Intended Audience :: Developers',
@@ -49,7 +47,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',

--- a/tests/models.py
+++ b/tests/models.py
@@ -2,14 +2,11 @@
 
 from __future__ import absolute_import, unicode_literals
 
-from django.db import models
 from django.conf import settings
+from django.db import models
 
 from horizon.manager import HorizontalManager
-from horizon.models import (
-    AbstractHorizontalMetadata,
-    AbstractHorizontalModel,
-)
+from horizon.models import AbstractHorizontalMetadata, AbstractHorizontalModel
 
 
 class HorizontalMetadata(AbstractHorizontalMetadata):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2,22 +2,22 @@
 
 from __future__ import absolute_import, unicode_literals
 
-from django.db import models
 from django.conf import settings
 from django.contrib.auth import get_user_model
+from django.db import models
 from django.test import TestCase
 
 from horizon.models import AbstractHorizontalModel
+
 from .base import HorizontalBaseTestCase
 from .models import (
     ConcreteModel,
-    ManyModel,
     HorizontalMetadata,
+    ManyModel,
     OneModel,
     ProxiedModel,
     ProxyBaseModel,
 )
-
 
 user_model = get_user_model()
 

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -2,18 +2,15 @@
 
 from __future__ import absolute_import, unicode_literals
 
-try:
-    from unittest.mock import patch
-except ImportError:
-    from mock import patch
+from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
 from django.db.utils import ProgrammingError
 
 from horizon.query import HorizontalQuerySet
+
 from .base import HorizontalBaseTestCase
 from .models import OneModel
-
 
 user_model = get_user_model()
 

--- a/tests/test_routers.py
+++ b/tests/test_routers.py
@@ -7,16 +7,16 @@ from unittest.mock import patch
 from django.contrib.auth import get_user_model
 
 from horizon.routers import HorizontalRouter
+
 from .base import HorizontalBaseTestCase
 from .models import (
     ConcreteModel,
-    ManyModel,
     HorizontalMetadata,
+    ManyModel,
     OneModel,
     ProxiedModel,
     ProxyBaseModel,
 )
-
 
 user_model = get_user_model()
 

--- a/tests/test_routers.py
+++ b/tests/test_routers.py
@@ -2,10 +2,7 @@
 
 from __future__ import absolute_import, unicode_literals
 
-try:
-    from unittest.mock import patch
-except ImportError:
-    from mock import patch
+from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,15 +8,16 @@ from django.test import TestCase, override_settings
 
 from horizon.utils import (
     get_config,
-    get_metadata_model,
-    get_group_from_model,
-    get_key_field_name_from_model,
     get_config_from_group,
     get_config_from_model,
     get_db_for_read_from_model_index,
     get_db_for_write_from_model_index,
+    get_group_from_model,
+    get_key_field_name_from_model,
+    get_metadata_model,
     get_or_create_index,
 )
+
 from .models import (
     ConcreteModel,
     HorizontalMetadata,
@@ -25,7 +26,6 @@ from .models import (
     ProxiedModel,
     ProxyBaseModel,
 )
-
 
 user_model = get_user_model()
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,9 @@
 [tox]
 skip_missing_interpreters = true
 envlist =
-  py{py,py3,27,33,34,35,36}-dj{19,110,111,20,dev},
+  py{py,py3,27,34,35,36}-dj111,
+  py{py3,34,35,36}-dj20,
+  py{py3,35,36}-djmaster,
   flake8,
   isort,
   readme,
@@ -10,18 +12,15 @@ envlist =
 [testenv]
 basepython =
   py27: python2.7
-  py33: python3.3
   py34: python3.4
   py35: python3.5
   py36: python3.6
   pypy: pypy
   pypy3: pypy3
 deps =
-  dj19: Django>=1.9,<1.10
-  dj110: Django>=1.10,<1.11
   dj111: Django>=1.11,<2.0
   dj20: Django>=2.0,<2.1
-  djdev: https://github.com/django/django/archive/master.tar.gz
+  djmaster: https://github.com/django/django/archive/master.tar.gz
   py27: mock
   coverage
   py36-dj20: codecov
@@ -35,21 +34,21 @@ commands =
   py36-dj20: codecov
 
 [testenv:flake8]
-basepython = python3.6
+basepython = python3
 deps = flake8
 commands = flake8
 
 [testenv:isort]
-basepython = python3.6
+basepython = python3
 deps = isort
-commands = isort --verbose --check-only --diff horizon tests setup.py
+commands = isort --recursive --verbose --check-only --diff horizon tests setup.py
 
 [testenv:readme]
-basepython = python3.6
+basepython = python3
 deps = readme_renderer
 commands = python setup.py check -r -s
 
 [testenv:check-manifest]
-basepython = python3.6
+basepython = python3
 deps = check-manifest
 commands = check-manifest {toxinidir}


### PR DESCRIPTION
- Remove EOL version (1.8, 1.9, 1.10 - from [roadmap](https://www.djangoproject.com/weblog/2015/jun/25/roadmap/))
- Fix missing recursive option bug for isort and that bugs